### PR TITLE
Add Himalayas as a remote job board

### DIFF
--- a/dist/remote-working-resources.html
+++ b/dist/remote-working-resources.html
@@ -34,6 +34,7 @@
 <li><a href='https://news.ycombinator.com/jobs'>Hacker News Jobs</a></li>
 <li><a href='https://hasjob.co/?l=anywhere'>HasJob</a></li>
 <li><a href='https://www.higheredjobs.com/search/remote.cfm'>HigherEd Jobs</a></li>
+<li><a href='https://himalayas.app/jobs'>Himalayas</a></li>
 <li><a href='https://talent.hubstaff.com/search/jobs'>Hubstaff</a></li>
 <li><a href='https://www.idealist.org/en/?radius=160000&amp;sort=relevance&amp;type=ALL'>Idealist</a></li>
 <li><a href='http://www.indeed.com/jobs?q=web+development&amp;l=remote'>Indeed</a></li>

--- a/dist/remote-working-resources.md
+++ b/dist/remote-working-resources.md
@@ -34,6 +34,7 @@
 - Hacker News Jobs (https://news.ycombinator.com/jobs)
 - HasJob (https://hasjob.co/?l=anywhere)
 - HigherEd Jobs (https://www.higheredjobs.com/search/remote.cfm)
+- Himalayas (https://himalayas.app/jobs)
 - Hubstaff (https://talent.hubstaff.com/search/jobs)
 - Idealist (https://www.idealist.org/en/?radius=160000&amp;sort=relevance&amp;type=ALL)
 - Indeed (http://www.indeed.com/jobs?q=web+development&amp;l=remote)

--- a/remote-working-resources.csv
+++ b/remote-working-resources.csv
@@ -35,6 +35,7 @@ Guru,https://www.guru.com/d/jobs/,https://www.guru.com/rss/jobs/,
 Hacker News Jobs,https://news.ycombinator.com/jobs,,No RSS feed for jobs but there is an API which would theoretically allow you to build one: https://github.com/HackerNews/API
 HasJob,https://hasjob.co/?l=anywhere,https://hasjob.co/feed,The have an Anywhere option under the location filter. Feed not filterable. Also on Twitter (@hasjob)
 HigherEd Jobs,https://www.higheredjobs.com/search/remote.cfm,,They have an Online/Remote Job section
+Himalayas,https://himalayas.app/jobs,,Dedicated remote job board
 Hubstaff,https://talent.hubstaff.com/search/jobs,,
 Idealist,https://www.idealist.org/en/?radius=160000&amp;sort=relevance&amp;type=ALL,,No RSS feed but there is an email subscription available
 Indeed,http://www.indeed.com/jobs?q=web+development&amp;l=remote,http://rss.indeed.com/rss,You can filter more specifically by passing the q parameter like this: http://rss.indeed.com/rss?q=web+development


### PR DESCRIPTION
Added https://himalayas.app/ as a remote job board resource.

Himalayas is a remote job board that offers a large range of remote-specific filters, jobs, and company profiles, including information about company tech stacks and benefits. It is free for job seekers to use to find remote jobs.